### PR TITLE
Fix writing to servos

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -184,7 +184,7 @@ Adaptor.prototype.analogRead = function(pin, callback) {
 Adaptor.prototype.servoWrite = function(pin, value) {
   this.pwmWrite(
     pin,
-    MIN_PULSE_WIDTH + value * (MAX_PULSE_WIDTH - MIN_PULSE_WIDTH),
+    MIN_PULSE_WIDTH + (value / 180) * (MAX_PULSE_WIDTH - MIN_PULSE_WIDTH),
     true
   );
 };


### PR DESCRIPTION
This fixes an issue with the equation used to calculate the pulse width, where the full number of degrees was being used instead of a percentage.