### PR TITLE
Adds optional 'i2cPort' param to specify communication particular i2c port

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -33,6 +33,7 @@ var Adaptor = module.exports = function Adaptor(opts) {
   this.pwmPins = [];
   this.analogPins = [];
   this.interval = opts.interval || 0.01;
+  this.i2cPort = opts.i2cPort;
   this.i2c = null;
 
   this.events = [
@@ -254,7 +255,7 @@ Adaptor.prototype.i2cWrite = function(address, cmd, buff, callback) {
  */
 Adaptor.prototype.i2cRead = function(address, cmd, length, callback) {
   if (this.i2c == null) {
-    this.i2c = new Mraa.I2c(utils.i2cPortFor());
+    this.i2c = new Mraa.I2c(this.i2cPort || utils.i2cPortFor());
   }
   this.i2c.address(address);
   this.i2c.write(new Buffer([cmd]));


### PR DESCRIPTION
Adds optional 'i2cPort' param to specify communication particular i2c port. For devices such as Sparkfun blocks.