### PR TITLE
Fixes cylon issue 326.

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -271,5 +271,9 @@ Adaptor.prototype.i2cRead = function(address, cmd, length, callback) {
   this.i2c.address(address);
   this.i2c.write(new Buffer([cmd]));
   var data = this.i2c.read(length);
-  callback(null, new Buffer(data, "ascii"));
+  if (data.length <= 0) {
+    callback(new Error("i2cRead: no data available. (Missing device?)"), null);
+  } else {
+    callback(null, new Buffer(data, "ascii"));
+  }
 };


### PR DESCRIPTION
The adaptor was not catching errors (0-length read) while reading from i2c. If
a device / sensor doesn't exist, no data will be available. This commit
ensures that the callback is called with an error indication if no data is
available.