### PR TITLE
Adds i2c port selection on write

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -247,7 +247,7 @@ Adaptor.prototype.analogWrite = Adaptor.prototype.pwmWrite;
  */
 Adaptor.prototype.i2cWrite = function(address, cmd, buff, callback) {
   if (this.i2c == null) {
-    this.i2c = new Mraa.I2c(utils.i2cPortFor());
+    this.i2c = new Mraa.I2c(this.i2cPort || utils.i2cPortFor());
   }
   this.i2c.address(address);
   this.i2c.write(new Buffer([cmd].concat(buff)));


### PR DESCRIPTION
In `adapter.js`, there is an option named `i2cPort` to set the i2c port. It is used [when reading from i2c](https://github.com/hybridgroup/cylon-intel-iot/blob/63262988f827b91d479e8e6168f06e3ab5808ba8/lib/adaptor.js#L269), but [not when writing](https://github.com/hybridgroup/cylon-intel-iot/blob/63262988f827b91d479e8e6168f06e3ab5808ba8/lib/adaptor.js#L250). This is causing me errors when I try to use the Sparkfun Edison boards, which use i2c port 1 by default. See #12.

This itty bitty PR  checks that option on write, too.
